### PR TITLE
Adding DEFAULT-DAG action tag

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -8,7 +8,6 @@ namespace WarriorSpecificFeatures\ExternalModule;
 
 use ExternalModules\AbstractExternalModule;
 use ExternalModules\ExternalModules;
-use Form;
 use Records;
 use REDCap;
 
@@ -91,8 +90,6 @@ class ExternalModule extends AbstractExternalModule {
      * @inheritdoc
      */
     function redcap_data_entry_form_top($project_id, string $record = NULL, $instrument, $event_id, $group_id = NULL, $repeat_instance = 1) {
-        $this->processDagActionTag($record, $instrument, $event_id, $repeat_instance);
-
         global $Proj;
 
         // Read our settings from the project configuration.
@@ -160,59 +157,5 @@ class ExternalModule extends AbstractExternalModule {
 
         // Use the @DEFAULT action tag to set the value we generated.
         $Proj->metadata[$target_field]['misc'] .= ' @DEFAULT="' . $res . '"';
-    }
-
-    /**
-     * Processes @DEFAULT-DAG action in a given form.
-     */
-    protected function processDagActionTag($record = null, $instrument, $event_id, $repeat_instance = 1) {
-        global $Proj;
-
-        if ($record) {
-            if (Records::formHasData($record, $instrument, $event_id, $repeat_instance)) {
-                // If form has data, there is no point in setting up default value.
-                return;
-            }
-
-            if (!$dag = Records::getRecordGroupId($Proj->project_id, $record)) {
-                // Form has no DAG.
-                return;
-            }
-        }
-        else {
-            global $user_rights;
-
-            $dag = $user_rights['group_id'];
-            if ($dag == '' || intval($dag) != $dag) {
-                // Record creator does not belong to any valid DAG.
-                return;
-            }
-        }
-
-        if (!isset($Proj->groups[$dag])) {
-            // The DAG is not valid.
-            return;
-        }
-
-        foreach (array_keys($Proj->forms[$instrument]['fields']) as $field_name) {
-            if (!$misc = $Proj->metadata[$field_name]['misc']) {
-                // If annotation data is empty, skip current field.
-                continue;
-            }
-
-            if (Form::getValueInQuotesActionTag($misc, '@DEFAULT')) {
-                // If @DEFAULT action tag is already set, skip current field.
-                continue;
-            }
-
-            $action_tags = explode(' ', $misc);
-            if (!in_array('@DEFAULT-DAG', $action_tags)) {
-                // If @DEFAULT-DAG action tag is not set, skip current field.
-                continue;
-            }
-
-            // Setting DAG as the default value for the current field.
-            $Proj->metadata[$field_name]['misc'] .= ' @DEFAULT="' . $dag . '"';
-        }
     }
 }

--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -17,6 +17,76 @@ use REDCap;
  */
 class ExternalModule extends AbstractExternalModule {
 
+    static protected $maxDateFields = [];
+
+    /**
+     * @inheritdoc
+     */
+    function redcap_every_page_before_render($project_id) {
+        if (!$project_id) {
+            return;
+        }
+
+        global $Proj;
+
+        $form = $_GET['page'];
+        foreach ($Proj->metadata as &$info) {
+            // Checking if field has the correct date format and contains
+            // @MAX-DATE action tag.
+            if ($info['element_validation_type'] == 'date_ymd' && ($prefix = Form::getValueInActionTag($info['misc'], '@MAX-DATE'))) {
+                self::$maxDateFields[$info['field_name']] = $prefix;
+
+                // Hiding the field from the end-users.
+                $info['misc'] .= ' @HIDDEN';
+            }
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    function redcap_save_record($project_id, $record = null, $instrument, $event_id, $group_id = null, $survey_hash = null, $response_id = null, $repeat_instance = 1) {
+        if (empty(self::$maxDateFields)) {
+            return;
+        }
+
+        global $Proj;
+
+        // Looping over all fields containing @MAX-DATE.
+        foreach (self::$maxDateFields as $field_name => $prefix) {
+            // Looking for date fields that match the given prefix.
+            if (!$date_fields = preg_grep('/^' . $prefix . '*/', array_keys($Proj->metadata))) {
+                continue;
+            }
+
+            $data = REDCap::getData($project_id, 'array', $record, $date_fields);
+
+            $max = 0;
+            foreach ($data[$record] as $values) {
+                foreach ($values as $value) {
+                    $timestamp = strtotime($value);
+
+                    if ($timestamp !== false && $timestamp > $max_timestamp) {
+                        // Storing max date.
+                        $max_timestamp = $timestamp;
+                        $max_date = $value;
+                    }
+                }
+            }
+
+            if ($max_timestamp) {
+                foreach ($Proj->eventsForms as $event_id => $forms) {
+                    if (in_array($Proj->metadata[$field_name]['form_name'], $forms)) {
+                        // Saving the max date into the action tagged field
+                        // only for the first event it appears.
+                        REDCap::saveData($project_id, 'array', [$record => [$event_id => [$field_name => $max_date]]]);
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
     /**
      * @inheritdoc
      */
@@ -53,7 +123,7 @@ class ExternalModule extends AbstractExternalModule {
         }
 
         // check if the required input fields are present in the project or not.
-        $req_fields = array($first_name_field, $last_name_field);
+        $req_fields = [$first_name_field, $last_name_field];
         foreach ($req_fields as $req_field) {
             if (!isset($Proj->metadata[$req_field])) {
                 return;

--- a/README.md
+++ b/README.md
@@ -2,26 +2,23 @@
 This is REDCap module provides specific features for the Warrior project.
 
 ## Prerequisites
-- REDCap >= 8.0.3
+- REDCap >= 8.0.0 (for versions < 8.0.0, [REDCap Modules](https://github.com/vanderbilt/redcap-external-modules) is required).
 
 ## Installation
 - Clone this repo into to `<redcap-root>/modules/warrior_specific_features_v<version_number>`.
-- Go to **Control Center > Manage External Modules** and enable Warrior Specific Features.
+- Go to **Control Center > Manage External Modules** and enable Linear Data Entry Workflow.
 - For each project you want to use this module, go to the project home page, click on **Manage External Modules** link, and then enable Warrior Specific Features for that project.
 
-## Action tags included
+## Features included
 
-### @SUBJECT-ID
-This action tag automatically:
+### Automatic Subject ID
+A new action tag is provided: `@SUBJECT-ID`, which automatically:
 - Sets the target field as read only
 - Sets a subject ID value to the target field in the following format: `<DAG_ID>-<GIVEN_NAME_INITIAL><SURNAME_INITIAL><RECORD_ID>`, e.g. for `2-101` as record ID, `John` as first name, and `Smith` as last name, the result will be `2-JS101`
-
-#### Note
-- If the DAG ID does not exist, then the DAG prefix will be ignored - e.g. the subject ID would be `JS101` instead of `2-JS101`
-- Given name and surname values must be saved prior to subject ID field, i.e. these fields should be placed in instruments that will be filled before subject ID field. You can force users to a linear workflow by installing [Linear Data Entry Workflow module](https://github.com/ctsit/linear_data_entry_workflow)
 
 #### Configuration
 By default, Automatic Subject ID looks for `first_name` and `last_name` fields. If your source fields are named differently, you may setup alternative sources. To do that, go to  **Manage External Modules** section of your project, click on WARRIOR Project Specific Feature's configure button, and fill fields under "Automatic subject ID" section.
 
-### @DEFAULT-DAG
-This action tag sets the current DAG ID (aka group ID) as the field's default value.
+#### Note
+- If the DAG ID does not exist, then the DAG prefix will be ignored - e.g. the subject ID would be `JS101` instead of `2-JS101`
+- Given name and surname values must be saved prior to subject ID field, i.e. these fields should be placed in instruments that will be filled before subject ID field. You can force users to a linear workflow by installing [Linear Data Entry Workflow module](https://github.com/ctsit/linear_data_entry_workflow)

--- a/README.md
+++ b/README.md
@@ -2,23 +2,26 @@
 This is REDCap module provides specific features for the Warrior project.
 
 ## Prerequisites
-- REDCap >= 8.0.0 (for versions < 8.0.0, [REDCap Modules](https://github.com/vanderbilt/redcap-external-modules) is required).
+- REDCap >= 8.0.3
 
 ## Installation
 - Clone this repo into to `<redcap-root>/modules/warrior_specific_features_v<version_number>`.
-- Go to **Control Center > Manage External Modules** and enable Linear Data Entry Workflow.
+- Go to **Control Center > Manage External Modules** and enable Warrior Specific Features.
 - For each project you want to use this module, go to the project home page, click on **Manage External Modules** link, and then enable Warrior Specific Features for that project.
 
-## Features included
+## Action tags included
 
-### Automatic Subject ID
-A new action tag is provided: `@SUBJECT-ID`, which automatically:
+### @SUBJECT-ID
+This action tag automatically:
 - Sets the target field as read only
 - Sets a subject ID value to the target field in the following format: `<DAG_ID>-<GIVEN_NAME_INITIAL><SURNAME_INITIAL><RECORD_ID>`, e.g. for `2-101` as record ID, `John` as first name, and `Smith` as last name, the result will be `2-JS101`
-
-#### Configuration
-By default, Automatic Subject ID looks for `first_name` and `last_name` fields. If your source fields are named differently, you may setup alternative sources. To do that, go to  **Manage External Modules** section of your project, click on WARRIOR Project Specific Feature's configure button, and fill fields under "Automatic subject ID" section.
 
 #### Note
 - If the DAG ID does not exist, then the DAG prefix will be ignored - e.g. the subject ID would be `JS101` instead of `2-JS101`
 - Given name and surname values must be saved prior to subject ID field, i.e. these fields should be placed in instruments that will be filled before subject ID field. You can force users to a linear workflow by installing [Linear Data Entry Workflow module](https://github.com/ctsit/linear_data_entry_workflow)
+
+#### Configuration
+By default, Automatic Subject ID looks for `first_name` and `last_name` fields. If your source fields are named differently, you may setup alternative sources. To do that, go to  **Manage External Modules** section of your project, click on WARRIOR Project Specific Feature's configure button, and fill fields under "Automatic subject ID" section.
+
+### @DEFAULT-DAG
+This action tag sets the current DAG ID (aka group ID) as the field's default value.

--- a/config.json
+++ b/config.json
@@ -3,7 +3,9 @@
     "namespace": "WarriorSpecificFeatures\\ExternalModule",
     "description": "This module contains features which are specific to the Warrior project. These extensions were not written in a generalized way for other projects.",
     "permissions": [
-        "hook_data_entry_form_top"
+        "redcap_every_page_before_render",
+        "redcap_save_record",
+        "redcap_data_entry_form_top"
     ],
     "authors": [
         {


### PR DESCRIPTION
Adds an action tag that sets the DAG ID as the default value.

Review steps:
- [ ] Make sure Warrior Specific Features is enabled for your project
- [ ] Add `@DEFAULT-DAG` action tag to any field of your choice (or create a new field)
- [ ] Log in as a non admin user which belongs to a DAG of your project
- [ ] In a new record page, access the _DAG form_ and make sure the DAG value is auto-filled correctly
- [ ] Create a new record, making sure the _DAG form_ is not saved yet
- [ ] Yet on that record, go to the blank _DAG form_ and make sure the DAG field is auto-filled correctly

Glossary:
- _DAG form_: the form where your action tagged field is located
