### PR TITLE
Adding prefix and zero padding to subject ID

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -26,6 +26,7 @@ class ExternalModule extends AbstractExternalModule {
         $settings = ExternalModules::getProjectSettingsAsArray($this->PREFIX, $project_id);
         $first_name_field = empty($settings['first_name']['value']) ? 'first_name' : $settings['first_name']['value'][0];
         $last_name_field = empty($settings['last_name']['value']) ? 'last_name' : $settings['last_name']['value'][0];
+        $subject_id_prefix = empty($settings['subject_id_prefix']['value']) ? 'WAR' : $settings['subject_id_prefix']['value'][0];
 
         // determine if any field on this form references the action tag that triggers subject-id-setting behavior.
         $action_tag = '@SUBJECT-ID';
@@ -76,14 +77,14 @@ class ExternalModule extends AbstractExternalModule {
 
         $rec_arr = explode('-', $record);
         if (count($rec_arr) == 2) {
-            $res .= $rec_arr[0] . '-';
+            $res .= $subject_id_prefix . str_pad($rec_arr[0], 2, '0', STR_PAD_LEFT) . '-';
             $s_record_id = $rec_arr[1];
         }
         else {
             $s_record_id = $rec_arr[0];
         }
 
-        $res .= strtoupper(substr($first_name, 0, 1) . substr($last_name, 0, 1)) . $s_record_id;
+        $res .= strtoupper(substr($first_name, 0, 1) . substr($last_name, 0, 1)) . str_pad($s_record_id, 3, '0', STR_PAD_LEFT);
 
         // Use the @DEFAULT action tag to set the value we generated.
         $Proj->metadata[$target_field]['misc'] .= ' @DEFAULT="' . $res . '"';

--- a/README.md
+++ b/README.md
@@ -14,11 +14,13 @@ This is REDCap module provides specific features for the Warrior project.
 ### Automatic Subject ID
 A new action tag is provided: `@SUBJECT-ID`, which automatically:
 - Sets the target field as read only
-- Sets a subject ID value to the target field in the following format: `<DAG_ID>-<GIVEN_NAME_INITIAL><SURNAME_INITIAL><RECORD_ID>`, e.g. for `2-101` as record ID, `John` as first name, and `Smith` as last name, the result will be `2-JS101`
+- Sets a subject ID value to the target field in the following format: `<PREFIX><DAG_ID>-<GIVEN_NAME_INITIAL><SURNAME_INITIAL><RECORD_ID>`, e.g. for `2-12`, `WAR` as prefix, as record ID, `John` as first name, and `Smith` as last name, the result will be `WAR02-JS012`.
+
+Obs.: Note that dag ID is zero-padded to 2 digits, and record ID is zero-padded to 3 digits.
 
 #### Configuration
-By default, Automatic Subject ID looks for `first_name` and `last_name` fields. If your source fields are named differently, you may setup alternative sources. To do that, go to  **Manage External Modules** section of your project, click on WARRIOR Project Specific Feature's configure button, and fill fields under "Automatic subject ID" section.
+By default, Automatic Subject ID looks for `first_name` and `last_name` fields, and take `WAR` prefix. If your source fields are named differently or if you need to change the prefix, go to  **Manage External Modules** section of your project, select Warrior Specific Feature to configure, and then fill out _Automatic subject ID_ section.
 
 #### Note
-- If the DAG ID does not exist, then the DAG prefix will be ignored - e.g. the subject ID would be `JS101` instead of `2-JS101`
+- If the DAG ID does not exist, then the DAG prefix will be ignored - e.g. the subject ID would be `JS012` instead of `WAR02-JS101`
 - Given name and surname values must be saved prior to subject ID field, i.e. these fields should be placed in instruments that will be filled before subject ID field. You can force users to a linear workflow by installing [Linear Data Entry Workflow module](https://github.com/ctsit/linear_data_entry_workflow)


### PR DESCRIPTION
Solves #6.

Review steps:
- [x] Read the updated documentation on README
- [x] Make sure your project contains a `@SUBJECT-ID` action-tagged field
- [x] Make sure your subject ID field works properly on default settings (i.e. it is set & displayed according to the layout defined in the documentation, including the prefix and the zero left padding)
- [x] Customize all Automatic Subject ID settings
- [x] Make sure your subject ID still works as expected