### PR TITLE
Showing @MAX-DATE fields to global admins

### DIFF
--- a/ExternalModule.php
+++ b/ExternalModule.php
@@ -39,7 +39,7 @@ class ExternalModule extends AbstractExternalModule {
                 self::$maxDateFields[$field_name] = $prefix;
 
                 // Hiding the field from the end-users.
-                $info['misc'] .= ' @HIDDEN';
+                $info['misc'] .= SUPER_USER || ACCOUNT_MANAGER ? ' @READONLY' : ' @HIDDEN';
             }
         }
 


### PR DESCRIPTION
Review steps:
- [x] Create a Y-m-d date field with `@DATE-MAX="some_prefix"` action tag
- [x] Logged as admin, make sure the field is read-only
- [ ] Logged as admin, make sure the field is hidden